### PR TITLE
Make it work without CUDA

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
     with torch.no_grad():
         generator = Generator().to(device)
         generator.eval()
-        g_checkpoint = torch.load(args.checkpoint_path)
+        g_checkpoint = torch.load(args.checkpoint_path, map_location=device)
         generator.load_state_dict(g_checkpoint['model_state_dict'], strict=False)
         step = g_checkpoint['step']
         alpha = g_checkpoint['alpha']

--- a/eval.py
+++ b/eval.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         generator = parallel.DistributedDataParallel(generator)
         generator = parallel.convert_syncbn_model(generator)
     else:
-        g_checkpoint = torch.load(args.checkpoint_path)
+        g_checkpoint = torch.load(args.checkpoint_path, map_location=device)
     
     generator.load_state_dict(g_checkpoint['model_state_dict'], strict=False)
     step = g_checkpoint['step']


### PR DESCRIPTION
Before, pytorch was raising a RuntimeError on non-CUDA machines as the correct device wasn't being passed to `torch.load`.